### PR TITLE
README.md: Fix lookup example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ fn main()
         "1.1.0.0/24",
         "1.1.1.0/24",
         "1.1.0.0/20",
-        "1.1.2.0/24"
+        "1.2.2.0/24"
     ];
 
     let iter = prefixes.iter().map(|x| x.parse::<Ipv4Prefix>().unwrap());


### PR DESCRIPTION
Adjust one of the IP addresses in the slice used to build the set, in order to fix one lookup example. Namely, when "1.1.2.0/24", it should be the result for the lookup for "1.1.2.2", having a longer matching prefix than "1.1.0.0/20".

We could fix the expected value in the assertion, but instead we align the contents of the set with the example in examples/lookup.rs.
