### PR TITLE
Derive Ord & PartialOrd Ipv4Prefix & IPv6Prefix

### DIFF
--- a/src/prefix/ipstd.rs
+++ b/src/prefix/ipstd.rs
@@ -15,7 +15,7 @@ use super::*;
 /// An Ipv4 prefix similar to [`Ipv4Net`] but with trailing bits
 ///  guaranteed to equal `0`
 #[repr(C)]
-#[derive(Copy, Clone, Default, Eq, PartialEq, Hash)]
+#[derive(Copy, Clone, Default, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Ipv4Prefix {
     pub(super) addr: u32,
     pub(super) len: u8
@@ -54,7 +54,7 @@ impl Ipv4Prefix {
 /// An Ipv4 prefix similar to [`Ipv6Net`] but with trailing bits
 ///  guaranteed to equal `0`
 #[repr(C)]
-#[derive(Copy, Clone, Default, Eq, PartialEq, Hash)]
+#[derive(Copy, Clone, Default, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Ipv6Prefix {
     pub(super) addr: u128,
     pub(super) len: u8


### PR DESCRIPTION
Derive traits Ord and PartialOrd for types Ipv4Prefix and IPv6Prefix.

Types Ipv4Net and Ipv6Net referred to in the documentation implement those traits.