### PR TITLE
Fix benchmarks

### DIFF
--- a/benches/ipv4_build.rs
+++ b/benches/ipv4_build.rs
@@ -6,7 +6,8 @@ use std::net::Ipv4Addr;
 use test::Bencher;
 
 use iptrie::*;
-use  ip_network_table_deps_treebitmap::IpLookupTable;
+use iptrie::set::{RTrieSet, LCTrieSet};
+use ip_network_table_deps_treebitmap::IpLookupTable;
 
 fn random_ipv4_prefix() -> impl Iterator<Item=Ipv4Prefix>
 {

--- a/benches/ipv4_lookup.rs
+++ b/benches/ipv4_lookup.rs
@@ -7,7 +7,8 @@ use test::Bencher;
 
 use ipnet::*;
 use iptrie::*;
-use  ip_network_table_deps_treebitmap::IpLookupTable;
+use iptrie::set::RTrieSet;
+use ip_network_table_deps_treebitmap::IpLookupTable;
 
 fn random_ipv4net() -> impl Iterator<Item=Ipv4Net>
 {

--- a/benches/ipv6_build.rs
+++ b/benches/ipv6_build.rs
@@ -6,7 +6,8 @@ use std::net::Ipv6Addr;
 use test::Bencher;
 
 use iptrie::*;
-use  ip_network_table_deps_treebitmap::IpLookupTable;
+use iptrie::set::{RTrieSet, LCTrieSet};
+use ip_network_table_deps_treebitmap::IpLookupTable;
 
 fn random_ipv6_prefix() -> impl Iterator<Item=Ipv6Prefix>
 {

--- a/benches/ipv6_lookup.rs
+++ b/benches/ipv6_lookup.rs
@@ -7,6 +7,7 @@ use test::Bencher;
 
 use ipnet::*;
 use iptrie::*;
+use iptrie::set::RTrieSet;
 use  ip_network_table_deps_treebitmap::IpLookupTable;
 
 fn random_ipv6net() -> impl Iterator<Item=Ipv6Net>
@@ -55,23 +56,10 @@ fn lookup_ipv6prefix_trie(bencher: &mut Bencher)
 }
 
 #[bench]
-fn lookup_ipv6prefix120_trie(bencher: &mut Bencher)
+fn lookup_ipv6netprefix_trie(bencher: &mut Bencher)
 {
     let trie: RTrieSet<_> = random_ipv6net()
-        .map(Ipv6Prefix120::try_from)
-        .collect::<Result<_,_>>()
-        .unwrap();
-    let mut sample = random_ipv6addr();
-    let mut result = Vec::with_capacity(1_000);
-    bencher.iter(|| result.push(trie.lookup(&sample.next().unwrap())) );
-    println!("{}", result.len());
-}
-
-#[bench]
-fn lookup_ipv6prefix56_trie(bencher: &mut Bencher)
-{
-    let trie: RTrieSet<_> = random_ipv6net()
-        .map(Ipv6Prefix56::try_from)
+        .map(Ipv6NetPrefix::try_from)
         .collect::<Result<_,_>>()
         .unwrap();
     let mut sample = random_ipv6addr();
@@ -116,24 +104,10 @@ fn lookup_ipv6prefix_lctrie(bencher: &mut Bencher)
 }
 
 #[bench]
-fn lookup_ipv6prefix120_lctrie(bencher: &mut Bencher)
+fn lookup_ipv6netprefix_lctrie(bencher: &mut Bencher)
 {
     let trie: RTrieSet<_> = random_ipv6net()
-        .map(Ipv6Prefix120::try_from)
-        .collect::<Result<_,_>>()
-        .unwrap();
-    let trie = trie.compress();
-    let mut sample = random_ipv6addr();
-    let mut result = Vec::with_capacity(1_000);
-    bencher.iter(|| result.push(trie.lookup(&sample.next().unwrap())) );
-    println!("{}", result.len());
-}
-
-#[bench]
-fn lookup_ipv6prefix56_lctrie(bencher: &mut Bencher)
-{
-    let trie: RTrieSet<_> = random_ipv6net()
-        .map(Ipv6Prefix56::try_from)
+        .map(Ipv6NetPrefix::try_from)
         .collect::<Result<_,_>>()
         .unwrap();
     let trie = trie.compress();


### PR DESCRIPTION
The benchmarks weren't updated following the changes that removed Ipv6Prefix120 and Ipv6Prefix56, and the ones that made RTrieSet not be exported from the root. I fixed that.